### PR TITLE
feat: Auto-generate navigation section IDs from titles

### DIFF
--- a/app/Filament/Resources/PostResource.php
+++ b/app/Filament/Resources/PostResource.php
@@ -75,17 +75,13 @@ class PostResource extends Resource
                     ->schema([
                         Repeater::make('navigation_sections')
                             ->label('Daftar Isi / Navigation')
-                            ->helperText('Tambahkan judul-judul dalam berita untuk navigation sidebar')
+                            ->helperText('Tambahkan judul-judul dalam berita untuk navigation sidebar. ID akan otomatis dibuat dari judul.')
                             ->schema([
-                                TextInput::make('id')
-                                    ->label('ID (tanpa spasi)')
-                                    ->required()
-                                    ->placeholder('contoh: pengertian-berbakti')
-                                    ->rules(['required', 'regex:/^[a-z0-9-]+$/']),
                                 TextInput::make('title')
                                     ->label('Judul Section')
                                     ->required()
-                                    ->placeholder('contoh: Apa itu Berbakti?'),
+                                    ->placeholder('contoh: Apa itu Berbakti?')
+                                    ->helperText('ID akan otomatis dibuat dari judul ini (contoh: "Apa itu Berbakti?" → "apa-itu-berbakti")'),
                                 // Pada bagian navigation_sections, tambahkan ke RichEditor content
                                 RichEditor::make('content')
                                     ->label('Isi Section')

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -8,6 +8,7 @@ use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\Sluggable\HasSlug;
 use Spatie\Sluggable\SlugOptions;
+use Illuminate\Support\Str;
 
 class Post extends Model implements HasMedia
 {
@@ -37,11 +38,82 @@ class Post extends Model implements HasMedia
         'navigation_sections' => 'array',
     ];
 
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::saving(function ($post) {
+            $post->processNavigationSections();
+        });
+    }
+
     public function getSlugOptions(): SlugOptions
     {
         return SlugOptions::create()
             ->generateSlugsFrom('title')
             ->saveSlugsTo('slug');
+    }
+
+    /**
+     * Process navigation sections to auto-generate IDs from titles
+     */
+    public function processNavigationSections()
+    {
+        if (!$this->navigation_sections) {
+            return;
+        }
+
+        $processedSections = [];
+        $usedIds = [];
+
+        foreach ($this->navigation_sections as $section) {
+            if (isset($section['title']) && !empty($section['title'])) {
+                // Generate ID from title
+                $baseId = $this->generateIdFromTitle($section['title']);
+                $uniqueId = $this->ensureUniqueId($baseId, $usedIds);
+                $usedIds[] = $uniqueId;
+
+                $processedSections[] = [
+                    'id' => $uniqueId,
+                    'title' => $section['title'],
+                    'content' => $section['content'] ?? '',
+                ];
+            }
+        }
+
+        $this->navigation_sections = $processedSections;
+    }
+
+    /**
+     * Generate a slug-like ID from title
+     */
+    private function generateIdFromTitle($title)
+    {
+        // Convert to lowercase and create slug
+        $slug = Str::slug($title, '-');
+        
+        // Ensure it starts with a letter (for valid HTML IDs)
+        if (preg_match('/^[0-9]/', $slug)) {
+            $slug = 'section-' . $slug;
+        }
+        
+        return $slug;
+    }
+
+    /**
+     * Ensure the ID is unique within the navigation sections
+     */
+    private function ensureUniqueId($baseId, $usedIds)
+    {
+        $uniqueId = $baseId;
+        $counter = 1;
+
+        while (in_array($uniqueId, $usedIds)) {
+            $uniqueId = $baseId . '-' . $counter;
+            $counter++;
+        }
+
+        return $uniqueId;
     }
 
     public function scopePublished($query)


### PR DESCRIPTION
- Add automatic ID generation logic in Post model using Str::slug()
- Remove manual ID input field from PostResource admin form
- Implement uniqueness handling for duplicate titles within same post
- Ensure valid HTML ID format (prefix with 'section-' if starts with number)
- Maintain backward compatibility with existing posts
- Update admin interface with helpful text explaining auto-generation

This eliminates the need for users to manually enter navigation section IDs, improving UX while maintaining the same JSON structure for API compatibility.